### PR TITLE
Fix gzip_decompress

### DIFF
--- a/rpm2cpio.py
+++ b/rpm2cpio.py
@@ -26,10 +26,7 @@ import sys
 import gzip
 import subprocess
 
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
+from io import BytesIO
 
 HAS_LZMA_MODULE = True
 try:
@@ -45,7 +42,7 @@ RPM_MAGIC = b'\xed\xab\xee\xdb'
 
 
 def gzip_decompress(data):
-    gzstream = StringIO(data)
+    gzstream = BytesIO(data)
     gzipper = gzip.GzipFile(fileobj=gzstream)
     data = gzipper.read()
     return data


### PR DESCRIPTION
Hello,

I used rpm2cpio.py for old gzipped rpm files and found a bug. I would appreciate it if you could approve this pull request.
